### PR TITLE
Fix Disqus loading under Firefox

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,8 +21,8 @@ comments: true
      */
     
     var disqus_config = function () {
-        this.page.url = "{{ page.url }}";  // Replace PAGE_URL with your page's canonical URL variable
-        this.page.identifier = {{ page.id }}; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+        this.page.url = '{{ page.url }}';  // Replace PAGE_URL with your page's canonical URL variable
+        this.page.identifier = '{{ page.id }}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
     };
     
     (function() {  // REQUIRED CONFIGURATION VARIABLE: EDIT THE SHORTNAME BELOW


### PR DESCRIPTION
Use single quotes for ```this.page.url``` and ```this.page.identifier```